### PR TITLE
Fix: use value-based QUrl for installation URL to avoid leak

### DIFF
--- a/Browser/qmlview.cpp
+++ b/Browser/qmlview.cpp
@@ -192,19 +192,19 @@ void QmlView::continueLoad()
         emit loadFinished(true);
 
         // Start DAPP install
-        if(m_installationUrl) {
+        if(!m_installationUrl.isEmpty()) {
             m_dappInstaller = &DappInstaller::instance();
 
-            QUrl dappUrl = UrlHelper::gitToDappUrl(*m_installationUrl);
-            m_api->qi()->setProgressInfoProperty("url", QVariant::fromValue(m_installationUrl->toString()));
+            QUrl dappUrl = UrlHelper::gitToDappUrl(m_installationUrl);
+            m_api->qi()->setProgressInfoProperty("url", QVariant::fromValue(m_installationUrl.toString()));
             m_api->qi()->setProgressInfoProperty("dappUrl", QVariant::fromValue(dappUrl));
 
             connect(m_dappInstaller, &DappInstaller::progressChanged, m_api->qi(), &Qi::setProgress);
             connect(m_dappInstaller, &DappInstaller::progressOutput, m_api->qi(), [this](QString message){
                 m_api->log()->debug(message);
             });
-            m_dappInstaller->installOrUpdate(*m_installationUrl, UrlHelper::urlToLocalPath(dappUrl, true).toLocalFile());
-            m_installationUrl = nullptr;
+            m_dappInstaller->installOrUpdate(m_installationUrl, UrlHelper::urlToLocalPath(dappUrl, true).toLocalFile());
+            m_installationUrl = QUrl();
         }
     }
 

--- a/Browser/qmlview.h
+++ b/Browser/qmlview.h
@@ -69,7 +69,7 @@ public:
 
     bool addToBookmark() override;
 
-    void setInstallationUrl(QUrl *url) {
+    void setInstallationUrl(const QUrl &url) {
         m_installationUrl = url;
     };
 
@@ -121,7 +121,7 @@ private:
 
     bool m_reloading = false;
 
-    QUrl *m_installationUrl = nullptr;
+    QUrl m_installationUrl;
 
     DappInstaller *m_dappInstaller = nullptr;
 

--- a/Browser/tabview.cpp
+++ b/Browser/tabview.cpp
@@ -70,14 +70,14 @@ void TabView::loadUrl(const QString &rawUrl)
 
 void TabView::installUrl(const QString &rawUrl)
 {
-    m_installationUrl = new QUrl(QUrl::fromUserInput(rawUrl));
-    if(m_installationUrl->isEmpty()) {
-        // todo: Goto error page
+    m_installationUrl = QUrl::fromUserInput(rawUrl);
+    if(m_installationUrl.isEmpty()) {
+        // TODO: show error page in the tab
         qWarning("Invalid URL");
         return;
     }
     if(DappInstaller::instance().proecessIsActive()) {
-        // todo: Goto error page
+        // TODO: show error page in the tab
         qWarning("Installation already in progress");
         return;
     }
@@ -126,8 +126,9 @@ void TabView::loadFinished()
     }
     if(UrlHelper::isLocalSource(m_reply->url())) {
         m_pageView->setContent(m_reply->readAll(), mimeType, m_reply->url());
-        if(m_installationUrl) {
+        if(!m_installationUrl.isEmpty()) {
           static_cast<QmlView*>(m_pageView)->setInstallationUrl(m_installationUrl);
+          m_installationUrl = QUrl();
         }
     } else {
         m_pageView->setUrl(m_reply->url());

--- a/Browser/tabview.h
+++ b/Browser/tabview.h
@@ -98,7 +98,7 @@ private:
 
     bool m_reload = false;
 
-    QUrl *m_installationUrl = nullptr;
+    QUrl m_installationUrl;
 
 };
 


### PR DESCRIPTION
Fixes a small heap leak and clarify ownership when installing a DApp from a git URL by replacing a heap-allocated QUrl* with value semantics (QUrl) and passing it to QmlView by const QUrl&